### PR TITLE
feat: add Input and ToggleVisibilityInput components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ecommerce",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^0.477.0",
         "next": "15.1.7",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -6137,6 +6138,14 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.477.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.477.0.tgz",
+      "integrity": "sha512-yCf7aYxerFZAbd8jHJxjwe1j7jEMPptjnaOqdYeirFnEy85cNR3/L+o0I875CYFYya+eEVzZSbNuRk8BZPDpVw==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "lucide-react": "^0.477.0",
     "next": "15.1.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/app/components/Input/Input.tsx
+++ b/src/app/components/Input/Input.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React from 'react';
+import { LucideIcon } from 'lucide-react';
+
+interface InputProps {
+  label?: string;
+  borderSize?: string;
+  borderColor?: string;
+  placeholder?: string;
+  icon?: LucideIcon;
+  iconColor?: string;
+  helperText?: string;
+  helperTextColor?: string;
+}
+
+const Input: React.FC<InputProps> = ({
+  label,
+  borderSize = '1px',
+  borderColor = 'gray',
+  placeholder = '',
+  icon: Icon,
+  iconColor = 'gray',
+  helperText = '',
+  helperTextColor = 'gray',
+}) => {
+  return (
+    <div className="flex w-full flex-col bg-white text-black">
+      {label && <label className="mb-1 font-medium">{label}</label>}
+      <div
+        className="relative flex items-center rounded-lg px-3 py-2"
+        style={{ border: `${borderSize} solid ${borderColor}` }}
+      >
+        <input
+          type="text"
+          placeholder={placeholder}
+          className="w-full outline-none"
+        />
+        {Icon && <Icon className="mr-2" color={iconColor} />}
+      </div>
+      {helperText && (
+        <p className="mt-1 text-sm" style={{ color: helperTextColor }}>
+          {helperText}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default Input;

--- a/src/app/components/Input/ToggleVisibilityInput.tsx
+++ b/src/app/components/Input/ToggleVisibilityInput.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+
+interface ToggleVisibilityInputProps {
+  label?: string;
+  borderSize?: string;
+  borderColor?: string;
+  placeholder?: string;
+  iconColor?: string;
+  helperText?: string;
+  helperTextColor?: string;
+}
+
+const ToggleVisibilityInput: React.FC<ToggleVisibilityInputProps> = ({
+  label,
+  borderSize = '1px',
+  borderColor = 'gray',
+  placeholder = '',
+  iconColor = 'gray',
+  helperText = '',
+  helperTextColor = 'gray',
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <div className="flex w-full flex-col bg-white text-black">
+      {label && <label className="mb-1 font-medium">{label}</label>}
+      <div
+        className="relative flex items-center rounded-lg px-3 py-2"
+        style={{ border: `${borderSize} solid ${borderColor}` }}
+      >
+        <input
+          type={isVisible ? 'text' : 'password'}
+          placeholder={placeholder}
+          className="w-full outline-none"
+        />
+        {isVisible ? (
+          <EyeOff
+            className="ml-2 cursor-pointer"
+            color={iconColor}
+            onClick={() => setIsVisible(false)}
+          />
+        ) : (
+          <Eye
+            className="ml-2 cursor-pointer"
+            color={iconColor}
+            onClick={() => setIsVisible(true)}
+          />
+        )}
+      </div>
+      {helperText && (
+        <p className="mt-1 text-sm" style={{ color: helperTextColor }}>
+          {helperText}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default ToggleVisibilityInput;


### PR DESCRIPTION
Dentro de la carpeta app, creé de la carpeta components y dentro de ésta la carpeta Input que contiene los componentes Input y ToggleVisibilityInput.

Input: componente que puedes especificar las props.
ToggleVisibilityInput: Igual que el Input pero con la funcionalidad de mostrar/ocultar el contenido.

Así se vería igual que el diseño en figma (esta página no la estoy subiendo)

![image](https://github.com/user-attachments/assets/f2118478-b1f1-4fb9-ad54-91e8bca7dbbd)
