### PR TITLE
fix: make phoneNumber and gender optional in registerSchema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^2.2.0",
         "@heroicons/react": "^2.2.0",
-        "@pharmatech/sdk": "^0.2.0",
+        "@pharmatech/sdk": "^0.2.1",
         "lucide-react": "^0.477.0",
         "next": "15.1.7",
         "react": "^19.0.0",
@@ -1865,9 +1865,9 @@
       }
     },
     "node_modules/@pharmatech/sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@pharmatech/sdk/-/sdk-0.2.0.tgz",
-      "integrity": "sha512-yGlFlLzTz5ylWzH/dhwxxygyYi81cbOaIQoUUNd4+L4tnwuoxoJu4giaaGPNL+QgUu/3WUa1Jy/hoP1oZaD2mw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@pharmatech/sdk/-/sdk-0.2.1.tgz",
+      "integrity": "sha512-CrKgQsBSxF2q6iIRtp6nP36yIcSNHrPxJwgQN5tTyKJGzRZ9ZxJbGGPxRqHQgAHIFw6n0D/eY+q5B4l07Av9zQ==",
       "dependencies": {
         "axios": "^1.8.1"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.2.0",
-    "@pharmatech/sdk": "^0.2.0",
+    "@pharmatech/sdk": "^0.2.1",
     "lucide-react": "^0.477.0",
     "next": "15.1.7",
     "react": "^19.0.0",

--- a/src/app/register/RegisterForm.tsx
+++ b/src/app/register/RegisterForm.tsx
@@ -88,14 +88,13 @@ export default function RegisterForm() {
         FEMALE = 'f',
       }
 
-      const mappedGender: UserGender =
-        formData.genero === 'hombre'
-          ? UserGender.MALE
-          : formData.genero === 'mujer'
-            ? UserGender.FEMALE
-            : (() => {
-                throw new Error('Invalid gender');
-              })();
+      let mappedGender: UserGender | null = null;
+
+      if (formData.genero === 'hombre') {
+        mappedGender = UserGender.MALE;
+      } else if (formData.genero === 'mujer') {
+        mappedGender = UserGender.FEMALE;
+      }
 
       const payload = {
         firstName: formData.nombre,
@@ -103,11 +102,10 @@ export default function RegisterForm() {
         email: formData.email,
         password: formData.password,
         documentId: formData.cedula,
-        phoneNumber: formData.telefono,
         birthDate: formData.fechaNacimiento,
+        phoneNumber: formData.telefono.trim() !== '' ? formData.telefono : null,
         gender: mappedGender,
       };
-
       try {
         const response = await api.auth.signUp(payload);
         console.log('SignUp response:', response);

--- a/src/lib/validations/registerSchema.ts
+++ b/src/lib/validations/registerSchema.ts
@@ -28,9 +28,10 @@ export const registerSchema = z
 
     telefono: z
       .string()
-      .nonempty('El número de teléfono es obligatorio')
-      .regex(
-        /^\+\d{8,15}$/,
+      .transform((value) => (value?.trim() === '' ? null : value))
+      .nullable()
+      .refine(
+        (value) => value === null || /^\+\d{8,15}$/.test(value),
         'El teléfono debe iniciar con + y tener entre 8 y 15 dígitos',
       ),
 
@@ -60,9 +61,14 @@ export const registerSchema = z
         },
       ),
 
-    genero: z.enum(['hombre', 'mujer'], {
-      errorMap: () => ({ message: 'Selecciona un género' }),
-    }),
+    genero: z
+      .string()
+      .transform((value) => (value?.trim() === '' ? null : value))
+      .nullable()
+      .refine(
+        (value) => value === null || value === 'hombre' || value === 'mujer',
+        'Selecciona un género',
+      ),
 
     password: z
       .string()


### PR DESCRIPTION
This PR updates the `registerSchema.ts` to make the `phoneNumber` and `gender` fields optional, while maintaining their respective validation rules when values are provided.

Following feedback from @andres15alvarez, optional fields are being transformed to `null` when left empty, to align with backend expectations.

**Note:** The fix to enforce a minimum registration age of 13 years was already implemented and completed during the previous sprint.

**Pending Work**  
Changes to `RegisterForm.tsx` are still pending and cannot be implemented yet because `phoneNumber` and `gender` are currently required fields in the SDK's `SignUpRequest` type. I am waiting for the backend team to update the SDK to make these fields optional, which will allow for proper handling in the form submission payload.

Once the SDK is updated, I will complete the changes in `RegisterForm.tsx` to conditionally include these fields in the payload only when provided by the user.