### PR TITLE
fix: update register minimum age validation to 14 years

### DIFF
--- a/src/lib/validations/registerSchema.ts
+++ b/src/lib/validations/registerSchema.ts
@@ -49,14 +49,14 @@ export const registerSchema = z
 
           const today = new Date();
           const minAllowedDate = new Date(
-            today.getFullYear() - 13,
+            today.getFullYear() - 14,
             today.getMonth(),
             today.getDate(),
           );
           return fechaDate <= minAllowedDate;
         },
         {
-          message: 'Debes tener al menos 13 años',
+          message: 'Debes tener al menos 14 años',
         },
       ),
 


### PR DESCRIPTION
This PR updates the `registerSchema.ts` to enforce a minimum age of 14 years for user registration. 

Validation Logic:

- Verifies that the user is at least 14 years old based on the current date.

Task Reference: Fix-2: Implementación de validación de edad mínima (14 años) en el proceso de registro