### PR TITLE
fix: change message in recover-password

### DIFF
--- a/src/app/recover-password/VerifyEmailForm.tsx
+++ b/src/app/recover-password/VerifyEmailForm.tsx
@@ -44,9 +44,7 @@ export default function VerifyEmailForm({ onNext }: VerifyEmailFormProps) {
     } catch (err) {
       console.error('Error en el forgotPassword:', err);
       setGeneralError('Error al enviar el correo');
-      toast.error(
-        'Email no encontrado, verifica que el correo sea de una cuenta existente.',
-      );
+      toast.error('Ingresa una dirección de correo válida.');
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
Cambie el mensaje cuando se ingresa un correo invalido, ya no se da el mensaje de que no existe el correo.

![image](https://github.com/user-attachments/assets/9c25bbdc-b7c8-4a7b-ab9a-e677dc32e3c6)
