### PR TITLE
Standardize validation schemas

### DIFF
--- a/src/app/register/RegisterForm.tsx
+++ b/src/app/register/RegisterForm.tsx
@@ -26,25 +26,25 @@ export default function RegisterForm() {
   }, [token, router]);
 
   const [formData, setFormData] = useState({
-    nombre: '',
-    apellido: '',
+    firstName: '',
+    lastName: '',
     email: '',
-    cedula: '',
-    telefono: '',
-    fechaNacimiento: '',
-    genero: '',
+    documentId: '',
+    phoneNumber: '',
+    birthDate: '',
+    gender: '',
     password: '',
     confirmPassword: '',
   });
 
   const [errors, setErrors] = useState({
-    nombre: '',
-    apellido: '',
+    firstName: '',
+    lastName: '',
     email: '',
-    cedula: '',
-    telefono: '',
-    fechaNacimiento: '',
-    genero: '',
+    documentId: '',
+    phoneNumber: '',
+    birthDate: '',
+    gender: '',
     password: '',
     confirmPassword: '',
   });
@@ -59,15 +59,15 @@ export default function RegisterForm() {
     };
 
   const handleGenderClick = (gender: 'hombre' | 'mujer') => {
-    if (formData.genero !== gender) {
-      setFormData({ ...formData, genero: gender });
-      setErrors({ ...errors, genero: '' });
+    if (formData.gender !== gender) {
+      setFormData({ ...formData, gender: gender });
+      setErrors({ ...errors, gender: '' });
     }
   };
 
   const handleDateSelect = (date: string) => {
-    setFormData({ ...formData, fechaNacimiento: date });
-    setErrors({ ...errors, fechaNacimiento: '' });
+    setFormData({ ...formData, birthDate: date });
+    setErrors({ ...errors, birthDate: '' });
   };
 
   const handleSubmit = useCallback(
@@ -80,13 +80,13 @@ export default function RegisterForm() {
       if (!result.success) {
         const { fieldErrors } = result.error.flatten();
         setErrors({
-          nombre: fieldErrors.nombre?.[0] ?? '',
-          apellido: fieldErrors.apellido?.[0] ?? '',
+          firstName: fieldErrors.firstName?.[0] ?? '',
+          lastName: fieldErrors.lastName?.[0] ?? '',
           email: fieldErrors.email?.[0] ?? '',
-          cedula: fieldErrors.cedula?.[0] ?? '',
-          telefono: fieldErrors.telefono?.[0] ?? '',
-          fechaNacimiento: fieldErrors.fechaNacimiento?.[0] ?? '',
-          genero: fieldErrors.genero?.[0] ?? '',
+          documentId: fieldErrors.documentId?.[0] ?? '',
+          phoneNumber: fieldErrors.phoneNumber?.[0] ?? '',
+          birthDate: fieldErrors.birthDate?.[0] ?? '',
+          gender: fieldErrors.gender?.[0] ?? '',
           password: fieldErrors.password?.[0] ?? '',
           confirmPassword: fieldErrors.confirmPassword?.[0] ?? '',
         });
@@ -101,20 +101,21 @@ export default function RegisterForm() {
 
       let mappedGender: UserGender | null = null;
 
-      if (formData.genero === 'hombre') {
+      if (formData.gender === 'hombre') {
         mappedGender = UserGender.MALE;
-      } else if (formData.genero === 'mujer') {
+      } else if (formData.gender === 'mujer') {
         mappedGender = UserGender.FEMALE;
       }
 
       const payload = {
-        firstName: formData.nombre,
-        lastName: formData.apellido,
+        firstName: formData.firstName,
+        lastName: formData.lastName,
         email: formData.email,
         password: formData.password,
-        documentId: formData.cedula,
-        birthDate: formData.fechaNacimiento,
-        phoneNumber: formData.telefono.trim() !== '' ? formData.telefono : null,
+        documentId: formData.documentId,
+        birthDate: formData.birthDate,
+        phoneNumber:
+          formData.phoneNumber.trim() !== '' ? formData.phoneNumber : null,
         gender: mappedGender,
       };
 
@@ -123,13 +124,13 @@ export default function RegisterForm() {
         console.log('SignUp response:', response);
         toast.success('Cuenta creada correctamente');
         setFormData({
-          nombre: '',
-          apellido: '',
+          firstName: '',
+          lastName: '',
           email: '',
-          cedula: '',
-          telefono: '',
-          fechaNacimiento: '',
-          genero: '',
+          documentId: '',
+          phoneNumber: '',
+          birthDate: '',
+          gender: '',
           password: '',
           confirmPassword: '',
         });
@@ -180,30 +181,30 @@ export default function RegisterForm() {
             <Input
               label="Nombre"
               placeholder="Nombre"
-              value={formData.nombre}
-              onChange={handleInputChange('nombre')}
+              value={formData.firstName}
+              onChange={handleInputChange('firstName')}
               borderColor={Colors.stroke}
               borderSize="1px"
             />
             <p
-              className={`min-h-[16px] text-xs text-red-500 ${errors.nombre ? 'visible' : 'invisible'}`}
+              className={`min-h-[16px] text-xs text-red-500 ${errors.firstName ? 'visible' : 'invisible'}`}
             >
-              {errors.nombre}
+              {errors.firstName}
             </p>
           </div>
           <div>
             <Input
               label="Apellido"
               placeholder="Apellido"
-              value={formData.apellido}
-              onChange={handleInputChange('apellido')}
+              value={formData.lastName}
+              onChange={handleInputChange('lastName')}
               borderColor={Colors.stroke}
               borderSize="1px"
             />
             <p
-              className={`min-h-[16px] text-xs text-red-500 ${errors.apellido ? 'visible' : 'invisible'}`}
+              className={`min-h-[16px] text-xs text-red-500 ${errors.lastName ? 'visible' : 'invisible'}`}
             >
-              {errors.apellido}
+              {errors.lastName}
             </p>
           </div>
         </div>
@@ -229,15 +230,15 @@ export default function RegisterForm() {
             <Input
               label="Cédula"
               placeholder="12345678"
-              value={formData.cedula}
-              onChange={handleInputChange('cedula')}
+              value={formData.documentId}
+              onChange={handleInputChange('documentId')}
               borderColor={Colors.stroke}
               borderSize="1px"
             />
             <p
-              className={`min-h-[16px] text-xs text-red-500 ${errors.cedula ? 'visible' : 'invisible'}`}
+              className={`min-h-[16px] text-xs text-red-500 ${errors.documentId ? 'visible' : 'invisible'}`}
             >
-              {errors.cedula}
+              {errors.documentId}
             </p>
           </div>
         </div>
@@ -246,16 +247,16 @@ export default function RegisterForm() {
           <div>
             <Input
               label="Número de teléfono"
-              placeholder="+584141234567"
-              value={formData.telefono}
-              onChange={handleInputChange('telefono')}
+              placeholder="584141234567"
+              value={formData.phoneNumber}
+              onChange={handleInputChange('phoneNumber')}
               borderColor={Colors.stroke}
               borderSize="1px"
             />
             <p
-              className={`min-h-[16px] text-xs text-red-500 ${errors.telefono ? 'visible' : 'invisible'}`}
+              className={`min-h-[16px] text-xs text-red-500 ${errors.phoneNumber ? 'visible' : 'invisible'}`}
             >
-              {errors.telefono}
+              {errors.phoneNumber}
             </p>
           </div>
           <div>
@@ -276,9 +277,9 @@ export default function RegisterForm() {
               </div>
             </div>
             <p
-              className={`min-h-[16px] text-xs text-red-500 ${errors.fechaNacimiento ? 'visible' : 'invisible'}`}
+              className={`min-h-[16px] text-xs text-red-500 ${errors.birthDate ? 'visible' : 'invisible'}`}
             >
-              {errors.fechaNacimiento}
+              {errors.birthDate}
             </p>
           </div>
           <div>
@@ -288,19 +289,19 @@ export default function RegisterForm() {
             <div className="flex gap-6">
               <RadioButton
                 text="Hombre"
-                selected={formData.genero === 'hombre'}
+                selected={formData.gender === 'hombre'}
                 onSelect={() => handleGenderClick('hombre')}
               />
               <RadioButton
                 text="Mujer"
-                selected={formData.genero === 'mujer'}
+                selected={formData.gender === 'mujer'}
                 onSelect={() => handleGenderClick('mujer')}
               />
             </div>
             <p
-              className={`min-h-[16px] text-xs text-red-500 ${errors.genero ? 'visible' : 'invisible'}`}
+              className={`min-h-[16px] text-xs text-red-500 ${errors.gender ? 'visible' : 'invisible'}`}
             >
-              {errors.genero}
+              {errors.gender}
             </p>
           </div>
         </div>

--- a/src/components/User/UserProfileForm.tsx
+++ b/src/components/User/UserProfileForm.tsx
@@ -120,21 +120,21 @@ export default function EditForm({
     const genderText = gender === UserGender.FEMALE ? 'mujer' : 'hombre';
 
     const result = editProfileSchema.safeParse({
-      nombre: firstName,
-      apellido: lastName,
-      telefono: phoneNumber,
-      fechaNacimiento: birthDate,
-      genero: genderText,
+      firstName: firstName,
+      lastName: lastName,
+      phoneNumber: phoneNumber,
+      birthDate: birthDate,
+      gender: genderText,
     });
 
     if (!result.success) {
       const { fieldErrors } = result.error.flatten();
       setErrors({
-        firstName: fieldErrors.nombre?.[0] ?? '',
-        lastName: fieldErrors.apellido?.[0] ?? '',
-        phoneNumber: fieldErrors.telefono?.[0] ?? '',
-        birthDate: fieldErrors.fechaNacimiento?.[0] ?? '',
-        gender: fieldErrors.genero?.[0] ?? '',
+        firstName: fieldErrors.firstName?.[0] ?? '',
+        lastName: fieldErrors.lastName?.[0] ?? '',
+        phoneNumber: fieldErrors.phoneNumber?.[0] ?? '',
+        birthDate: fieldErrors.birthDate?.[0] ?? '',
+        gender: fieldErrors.gender?.[0] ?? '',
       });
       return;
     }

--- a/src/lib/validations/checkoutPaymentProcessSchema.ts
+++ b/src/lib/validations/checkoutPaymentProcessSchema.ts
@@ -33,7 +33,7 @@ export const checkoutPaymentProcessSchema = z.object({
     .string()
     .trim() // Elimina espacios en blanco al inicio y al final
     .refine(
-      (value) => /^\+\d{8,15}$/.test(value), // El teléfono debe iniciar con + y tener entre 8 y 15 dígitos
-      'El teléfono debe iniciar con + y tener entre 8 y 15 dígitos',
+      (value) => /^\d{8,15}$/.test(value),
+      'El teléfono debe tener entre 8 y 15 dígitos numéricos',
     ),
 });

--- a/src/lib/validations/loginSchema.ts
+++ b/src/lib/validations/loginSchema.ts
@@ -5,6 +5,10 @@ export const loginSchema = z.object({
     .string()
     .nonempty('El email es obligatorio')
     .email('Formato de email inválido'),
-  password: z.string().nonempty('La contraseña es obligatoria'),
-  //.min(6, 'La contraseña debe tener al menos 6 caracteres'),
+
+  password: z
+    .string()
+    .nonempty('La contraseña es obligatoria')
+    .min(8, 'La contraseña debe tener al menos 8 caracteres')
+    .max(255, 'La contraseña no puede exceder los 255 caracteres'),
 });

--- a/src/lib/validations/recoverPasswordSchema.ts
+++ b/src/lib/validations/recoverPasswordSchema.ts
@@ -11,15 +11,13 @@ export const resetPasswordSchema = z
       .string()
       .nonempty('La contraseña es obligatoria')
       .min(8, 'La contraseña debe tener al menos 8 caracteres')
-      .regex(/[A-Z]/, 'Debe tener al menos una letra mayúscula')
-      .regex(/[a-z]/, 'Debe tener al menos una letra minúscula')
-      .regex(/\d/, 'Debe tener al menos un número')
-      .regex(
-        /[!@#$%^&*]/,
-        'Debe tener al menos un símbolo especial (!@#$%^&*)',
-      ),
+      .max(255, 'La contraseña no puede exceder 255 caracteres'),
 
-    confirmPassword: z.string().nonempty('La confirmación es obligatoria'),
+    confirmPassword: z
+      .string()
+      .nonempty('La confirmación es obligatoria')
+      .min(8, 'La contraseña debe tener al menos 8 caracteres')
+      .max(255, 'La contraseña no puede exceder 255 caracteres'),
   })
   .refine((data) => data.newPassword === data.confirmPassword, {
     message: 'Las contraseñas no coinciden',

--- a/src/lib/validations/recoverPasswordSchema.ts
+++ b/src/lib/validations/recoverPasswordSchema.ts
@@ -10,11 +10,16 @@ export const resetPasswordSchema = z
     newPassword: z
       .string()
       .nonempty('La contraseña es obligatoria')
-      .min(8, 'La contraseña debe tener al menos 8 caracteres'),
-    confirmPassword: z
-      .string()
-      .nonempty('La confirmación es obligatoria')
-      .min(8, 'La contraseña debe tener al menos 8 caracteres'),
+      .min(8, 'La contraseña debe tener al menos 8 caracteres')
+      .regex(/[A-Z]/, 'Debe tener al menos una letra mayúscula')
+      .regex(/[a-z]/, 'Debe tener al menos una letra minúscula')
+      .regex(/\d/, 'Debe tener al menos un número')
+      .regex(
+        /[!@#$%^&*]/,
+        'Debe tener al menos un símbolo especial (!@#$%^&*)',
+      ),
+
+    confirmPassword: z.string().nonempty('La confirmación es obligatoria'),
   })
   .refine((data) => data.newPassword === data.confirmPassword, {
     message: 'Las contraseñas no coinciden',

--- a/src/lib/validations/registerSchema.ts
+++ b/src/lib/validations/registerSchema.ts
@@ -30,8 +30,8 @@ const baseSchema = z.object({
     .transform((value) => (value?.trim() === '' ? null : value))
     .nullable()
     .refine(
-      (value) => value === null || /^\+\d{8,15}$/.test(value),
-      'El teléfono debe iniciar con + y tener entre 8 y 15 dígitos',
+      (value) => value === null || /^\d{8,15}$/.test(value),
+      'El teléfono debe tener entre 8 y 15 dígitos numéricos',
     ),
 
   fechaNacimiento: z

--- a/src/lib/validations/registerSchema.ts
+++ b/src/lib/validations/registerSchema.ts
@@ -62,9 +62,10 @@ const baseSchema = z.object({
 
   gender: z
     .string()
-    .nonempty('Selecciona un género')
+    .transform((val) => (val?.trim() === '' ? null : val))
+    .nullable()
     .refine(
-      (value) => value === 'hombre' || value === 'mujer',
+      (value) => value === null || value === 'hombre' || value === 'mujer',
       'Selecciona un género válido',
     ),
 

--- a/src/lib/validations/registerSchema.ts
+++ b/src/lib/validations/registerSchema.ts
@@ -1,31 +1,31 @@
 import { z } from 'zod';
 
 const baseSchema = z.object({
-  nombre: z
+  firstName: z
     .string()
+    .nonempty('El nombre es obligatorio')
     .min(2, 'El nombre debe tener al menos 2 caracteres')
     .max(50, 'El nombre no puede exceder los 50 caracteres')
-    .regex(/^[a-zA-Z\s]+$/, 'El nombre solo puede contener letras')
-    .nonempty('El nombre es obligatorio'),
+    .regex(/^[a-zA-Z\s]+$/, 'El nombre solo puede contener letras'),
 
-  apellido: z
+  lastName: z
     .string()
+    .nonempty('El apellido es obligatorio')
     .min(2, 'El apellido debe tener al menos 2 caracteres')
     .max(50, 'El apellido no puede exceder los 50 caracteres')
-    .regex(/^[a-zA-Z\s]+$/, 'El apellido solo puede contener letras')
-    .nonempty('El apellido es obligatorio'),
+    .regex(/^[a-zA-Z\s]+$/, 'El apellido solo puede contener letras'),
 
   email: z
     .string()
     .nonempty('El email es obligatorio')
     .email('Formato de email inválido'),
 
-  cedula: z
+  documentId: z
     .string()
     .nonempty('La cédula es obligatoria')
     .regex(/^\d+$/, 'La cédula debe contener solo números'),
 
-  telefono: z
+  phoneNumber: z
     .string()
     .transform((value) => (value?.trim() === '' ? null : value))
     .nullable()
@@ -34,7 +34,7 @@ const baseSchema = z.object({
       'El teléfono debe tener entre 8 y 15 dígitos numéricos',
     ),
 
-  fechaNacimiento: z
+  birthDate: z
     .string()
     .nonempty('La fecha de nacimiento es obligatoria')
     .regex(
@@ -60,7 +60,7 @@ const baseSchema = z.object({
       },
     ),
 
-  genero: z
+  gender: z
     .string()
     .nonempty('Selecciona un género')
     .refine(
@@ -72,12 +72,13 @@ const baseSchema = z.object({
     .string()
     .nonempty('La contraseña es obligatoria')
     .min(8, 'La contraseña debe tener al menos 8 caracteres')
-    .regex(/[A-Z]/, 'Debe tener al menos una letra mayúscula')
-    .regex(/[a-z]/, 'Debe tener al menos una letra minúscula')
-    .regex(/\d/, 'Debe tener al menos un número')
-    .regex(/[!@#$%^&*]/, 'Debe tener al menos un símbolo especial (!@#$%^&*)'),
+    .max(255, 'La contraseña no puede exceder los 255 caracteres'),
 
-  confirmPassword: z.string().nonempty('Debes confirmar la contraseña'),
+  confirmPassword: z
+    .string()
+    .nonempty('Debes confirmar la contraseña')
+    .min(8, 'La contraseña debe tener al menos 8 caracteres')
+    .max(255, 'La contraseña no puede exceder los 255 caracteres'),
 });
 
 export const registerSchema = baseSchema.refine(
@@ -92,5 +93,5 @@ export const editProfileSchema = baseSchema.omit({
   password: true,
   confirmPassword: true,
   email: true,
-  cedula: true,
+  documentId: true,
 });

--- a/src/lib/validations/updatePasswordSchema.ts
+++ b/src/lib/validations/updatePasswordSchema.ts
@@ -2,21 +2,23 @@ import { z } from 'zod';
 
 export const updatePasswordSchema = z
   .object({
-    password: z.string().nonempty('La contraseña actual es obligatoria'),
+    password: z
+      .string()
+      .nonempty('La contraseña actual es obligatoria')
+      .min(8, 'La contraseña debe tener al menos 8 caracteres')
+      .max(255, 'La contraseña no puede exceder 255 caracteres'),
 
     newPassword: z
       .string()
       .nonempty('La contraseña es obligatoria')
       .min(8, 'La contraseña debe tener al menos 8 caracteres')
-      .regex(/[A-Z]/, 'Debe tener al menos una letra mayúscula')
-      .regex(/[a-z]/, 'Debe tener al menos una letra minúscula')
-      .regex(/\d/, 'Debe tener al menos un número')
-      .regex(
-        /[!@#$%^&*]/,
-        'Debe tener al menos un símbolo especial (!@#$%^&*)',
-      ),
+      .max(255, 'La contraseña no puede exceder 255 caracteres'),
 
-    confirmPassword: z.string().nonempty('La confirmación es obligatoria'),
+    confirmPassword: z
+      .string()
+      .nonempty('La confirmación es obligatoria')
+      .min(8, 'La contraseña debe tener al menos 8 caracteres')
+      .max(255, 'La contraseña no puede exceder 255 caracteres'),
   })
   .refine((data) => data.newPassword === data.confirmPassword, {
     message: 'Las contraseñas no coinciden',

--- a/src/lib/validations/updatePasswordSchema.ts
+++ b/src/lib/validations/updatePasswordSchema.ts
@@ -2,18 +2,21 @@ import { z } from 'zod';
 
 export const updatePasswordSchema = z
   .object({
-    password: z
-      .string()
-      .nonempty('La contraseña es obligatoria')
-      .min(8, 'La contraseña debe tener al menos 8 caracteres'),
+    password: z.string().nonempty('La contraseña actual es obligatoria'),
+
     newPassword: z
       .string()
       .nonempty('La contraseña es obligatoria')
-      .min(8, 'La contraseña debe tener al menos 8 caracteres'),
-    confirmPassword: z
-      .string()
-      .nonempty('La confirmación es obligatoria')
-      .min(8, 'La contraseña debe tener al menos 8 caracteres'),
+      .min(8, 'La contraseña debe tener al menos 8 caracteres')
+      .regex(/[A-Z]/, 'Debe tener al menos una letra mayúscula')
+      .regex(/[a-z]/, 'Debe tener al menos una letra minúscula')
+      .regex(/\d/, 'Debe tener al menos un número')
+      .regex(
+        /[!@#$%^&*]/,
+        'Debe tener al menos un símbolo especial (!@#$%^&*)',
+      ),
+
+    confirmPassword: z.string().nonempty('La confirmación es obligatoria'),
   })
   .refine((data) => data.newPassword === data.confirmPassword, {
     message: 'Las contraseñas no coinciden',


### PR DESCRIPTION
# 📦 Standardize Validation Schemas

This PR unifies the validation rules for the `password` and `phoneNumber` fields across all **e-commerce validation schemas**, with the exception of `userAddressSchema`, which remains unchanged.

The changes improve consistency, clarity, and user input validation across the system.

---

## 🔐 Password Validation

Passwords must now meet the following criteria:

- Minimum of **8 characters**
- Maximum of **255 characters**

This update affects all relevant fields such as `password`, `newPassword`, and `confirmPassword`.

---

## 📞 Phone Number Validation

- The `+` symbol is no longer required
- Only **numeric strings** with **8 to 15 digits** are accepted

---

## ✅ Modified Schemas

- `registerSchema.ts`
- `loginSchema.ts`
- `updatePasswordSchema.ts`
- `recoverPasswordSchema.ts`
- `editProfileSchema.ts`
- `checkoutPaymentProcessSchema.ts`

> 🔸 _Note: `userAddressSchema` was not modified._